### PR TITLE
feat: add clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,4 @@ A modified version of http://github.com/dgryski/go-topk with the following chang
 * [x] Add msgp encoding/decoding
 * [x] Use metro hash
 * [x] Allow merging via https://ieeexplore.ieee.org/document/8438445
+* [x] Clear state

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/axiomhq/topk
 
-go 1.17
+go 1.24
 
 require (
 	github.com/dgryski/go-metro v0.0.0-20211217172704-adc40b04c140

--- a/topk.go
+++ b/topk.go
@@ -153,6 +153,11 @@ func (tk *keys) Pop() interface{} {
 	return e
 }
 
+func (tk *keys) Clear() {
+	clear(tk.m)
+	tk.elts = tk.elts[:0]
+}
+
 // Stream calculates the TopK elements for a stream
 type Stream struct {
 	n      int
@@ -396,6 +401,16 @@ func (s *Stream) Decode(r io.Reader) error {
 	return s.DecodeMsgp(rdr)
 }
 
+// Clear resets the Stream to its initial empty state.
+// Clear does not change the size of the Stream.
+// Clear is not thread-safe, should not use it concurrently with other methods.
+func (s *Stream) Clear() {
+	s.k.Clear()
+	for i := range s.alphas {
+		s.alphas[i] = 0
+	}
+}
+
 const defaultScaleFactorM = 2
 
 // This is a simple wrapper around the Stream struct, more of a helper of sort
@@ -481,4 +496,12 @@ func (t *TopK) Encode(w io.Writer) error {
 // Decode ...
 func (t *TopK) Decode(r io.Reader) error {
 	return t.DecodeMsgp(msgp.NewReader(r))
+}
+
+// Clear resets the TopK to its initial empty state.
+// Clear preserves the initial k value.
+// Clear is not thread-safe, should not use it concurrently with other methods.
+func (t *TopK) Clear() {
+	t.c = 0
+	t.Stream.Clear()
 }

--- a/topk.go
+++ b/topk.go
@@ -406,9 +406,7 @@ func (s *Stream) Decode(r io.Reader) error {
 // Clear is not thread-safe, should not use it concurrently with other methods.
 func (s *Stream) Clear() {
 	s.k.Clear()
-	for i := range s.alphas {
-		s.alphas[i] = 0
-	}
+	clear(s.alphas)
 }
 
 const defaultScaleFactorM = 2

--- a/topk_test.go
+++ b/topk_test.go
@@ -459,6 +459,7 @@ func TestTopKClear(t *testing.T) {
 	assert.Equal(t, 0, len(keys))
 	est := tk.Estimate("apple")
 	assert.Equal(t, 0, est.Count)
+	assert.Equal(t, 10, tk.k)
 }
 
 func TestStreamClear(t *testing.T) {
@@ -475,4 +476,5 @@ func TestStreamClear(t *testing.T) {
 
 	est := stream.Estimate("foo")
 	assert.Equal(t, 0, est.Count)
+	assert.Equal(t, 10, stream.n)
 }

--- a/topk_test.go
+++ b/topk_test.go
@@ -443,3 +443,36 @@ func TestMarshalUnMarshal(t *testing.T) {
 	assert.EqualValues(t, sketch, tmp)
 
 }
+
+func TestTopKClear(t *testing.T) {
+	tk := New(10)
+
+	tk.Insert("apple", 5)
+	tk.Insert("banana", 3)
+	tk.Insert("cherry", 7)
+	tk.Insert("date", 2)
+
+	tk.Clear()
+
+	assert.Equal(t, 0, tk.Count())
+	keys := tk.Keys()
+	assert.Equal(t, 0, len(keys))
+	est := tk.Estimate("apple")
+	assert.Equal(t, 0, est.Count)
+}
+
+func TestStreamClear(t *testing.T) {
+	stream := newStream(10)
+
+	stream.Insert("foo", 5)
+	stream.Insert("bar", 3)
+	stream.Insert("baz", 8)
+
+	stream.Clear()
+
+	keys := stream.Keys()
+	assert.Equal(t, 0, len(keys))
+
+	est := stream.Estimate("foo")
+	assert.Equal(t, 0, est.Count)
+}


### PR DESCRIPTION
Our company use fixed-window, so we frequently allocation new TopK. But if "Clear" Method is provided, more convenient for developers.

Go version update to 1.24. Because I use "clear" method introduced in the 1.21. If you want not to change version, I will change it.